### PR TITLE
fix: inverted single-principal check

### DIFF
--- a/src/evaluation/context.rs
+++ b/src/evaluation/context.rs
@@ -4,10 +4,12 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[allow(dead_code)] // rust 1.90.0 says it's unused
 struct StringList(Vec<String>);
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[allow(dead_code)] // rust 1.90.0 says it's unused
 struct BooleanList(Vec<bool>);
 
 /// Represents different types of context values

--- a/src/evaluation/engine.rs
+++ b/src/evaluation/engine.rs
@@ -11,7 +11,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 /// Result of policy evaluation
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub enum Decision {
     /// Access is explicitly allowed

--- a/src/evaluation/engine.rs
+++ b/src/evaluation/engine.rs
@@ -255,24 +255,26 @@ impl PolicyEvaluator {
     ) -> Result<StatementMatch, EvaluationError> {
         // Check if principal matches (for resource-based policies)
         if let Some(ref principal) = statement.principal
-            && !Self::principal_matches(principal, &request.principal)? {
-                return Ok(StatementMatch {
-                    sid: statement.sid.clone(),
-                    effect: statement.effect,
-                    conditions_satisfied: false,
-                    reason: "Principal does not match".to_string(),
-                });
-            }
+            && !Self::principal_matches(principal, &request.principal)?
+        {
+            return Ok(StatementMatch {
+                sid: statement.sid.clone(),
+                effect: statement.effect,
+                conditions_satisfied: false,
+                reason: "Principal does not match".to_string(),
+            });
+        }
 
         if let Some(ref not_principal) = statement.not_principal
-            && Self::principal_matches(not_principal, &request.principal)? {
-                return Ok(StatementMatch {
-                    sid: statement.sid.clone(),
-                    effect: statement.effect,
-                    conditions_satisfied: false,
-                    reason: "Principal matches NotPrincipal exclusion".to_string(),
-                });
-            }
+            && Self::principal_matches(not_principal, &request.principal)?
+        {
+            return Ok(StatementMatch {
+                sid: statement.sid.clone(),
+                effect: statement.effect,
+                conditions_satisfied: false,
+                reason: "Principal matches NotPrincipal exclusion".to_string(),
+            });
+        }
 
         // Check if action matches
         let action_matches = if let Some(ref action) = statement.action {
@@ -324,14 +326,15 @@ impl PolicyEvaluator {
 
         // Check conditions
         if let Some(ref condition_block) = statement.condition
-            && !Self::evaluate_conditions(condition_block, &request.context)? {
-                return Ok(StatementMatch {
-                    sid: statement.sid.clone(),
-                    effect: statement.effect,
-                    conditions_satisfied: false,
-                    reason: "Conditions not satisfied".to_string(),
-                });
-            }
+            && !Self::evaluate_conditions(condition_block, &request.context)?
+        {
+            return Ok(StatementMatch {
+                sid: statement.sid.clone(),
+                effect: statement.effect,
+                conditions_satisfied: false,
+                reason: "Conditions not satisfied".to_string(),
+            });
+        }
 
         // All checks passed
         Ok(StatementMatch {
@@ -347,7 +350,7 @@ impl PolicyEvaluator {
         principal: &Principal,
         request_principal: &Principal,
     ) -> Result<bool, EvaluationError> {
-        if request_principal.is_single() {
+        if !request_principal.is_single() {
             return Err(EvaluationError::InvalidRequest(
                 "Request principal must be a single entity".to_string(),
             ));


### PR DESCRIPTION
In `PolicyEvaluator::principal_matches` the check wasn't ensuring a singular principal, fixed. 

Also some rando warnings that clippy was complaining about.