### PR TITLE
Remove `serde_with` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,49 +16,6 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -80,12 +31,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "iam-rs"
 version = "0.1.0"
 dependencies = [
@@ -93,15 +38,8 @@ dependencies = [
  "ipnet",
  "serde",
  "serde_json",
- "serde_with",
  "utoipa",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -134,12 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,12 +79,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -216,39 +142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,25 +151,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,12 @@ repository = "https://github.com/foorack/iam-rs"
 version = "0.1.0"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive", "alloc"], default-features = false }
+serde = { version = "1.0.228", features = [
+    "derive",
+    "alloc",
+], default-features = false }
 serde_json = { version = "1.0.149", features = [
     "std",
-], default-features = false }
-serde_with = { version = "3.18.0", features = [
-    "macros",
-    "alloc",
 ], default-features = false }
 chrono = { version = "0.4.44", features = [
     "alloc",

--- a/src/policy/policy.rs
+++ b/src/policy/policy.rs
@@ -4,10 +4,42 @@ use crate::{
     validation::{Validate, ValidationContext, ValidationError, ValidationResult, helpers},
 };
 use serde::{Deserialize, Serialize};
-use serde_with::OneOrMany;
-use serde_with::formats::PreferOne;
-use serde_with::serde_as;
 use std::collections::HashSet;
+
+mod one_or_many {
+    use serde::de::DeserializeOwned;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<T, S>(value: &Vec<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+        S: Serializer,
+    {
+        if value.len() == 1 {
+            value[0].serialize(serializer)
+        } else {
+            value.serialize(serializer)
+        }
+    }
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+    where
+        T: DeserializeOwned,
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum OneOrMany<T> {
+            One(T),
+            Many(Vec<T>),
+        }
+
+        match OneOrMany::deserialize(deserializer)? {
+            OneOrMany::One(val) => Ok(vec![val]),
+            OneOrMany::Many(vals) => Ok(vals),
+        }
+    }
+}
 
 /// JSON policy documents are made up of elements.
 /// The elements are listed here in the general order you use them in a policy.
@@ -26,7 +58,6 @@ use std::collections::HashSet;
 /// When you create or edit a JSON policy, `iam-rw` can perform policy validation to help you create an effective policy.
 ///
 /// <https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html>
-#[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct IAMPolicy {
@@ -57,8 +88,7 @@ pub struct IAMPolicy {
     /// For multiple statements, the array must be enclosed in square brackets [ ].
     ///
     /// <https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html>
-    #[serde(rename = "Statement")]
-    #[serde_as(as = "OneOrMany<_, PreferOne>")]
+    #[serde(rename = "Statement", with = "one_or_many")]
     #[cfg_attr(
         feature = "utoipa",
         schema(value_type = IAMStatements)


### PR DESCRIPTION
Replaces the `serde_with` crate with a small inline `one_or_many` module, eliminating an external dependency while preserving identical behaviour.

**Changes**
- Added a `one_or_many` module in policy.rs with custom `serialize`/`deserialize` functions that handle both a single object and an array for the `Statement` field
- Replaced `#[serde_as]` + `OneOrMany<_, PreferOne>` annotations with `#[serde(with = "one_or_many")]`
- Removed `serde_with` (and its transitive dependencies: `serde_with_macros`, `darling`, `darling_core`, `darling_macro`, `ident_case`) from Cargo.toml and Cargo.lock

**Behaviour**
- Deserialises `Statement` from either a single object or an array (unchanged)
- Serialises `Statement` as a single object when there is only one statement, otherwise as an array (unchanged, equivalent to `PreferOne`)